### PR TITLE
Removed submodules and added HexColor source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ profile
 DerivedData
 .idea/
 *.hmap
+Example/Pods/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Submodules/HexColors"]
-	path = Submodules/HexColors
-	url = https://github.com/mRs-/HexColors.git

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,15 +1,17 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
+platform :ios, '8.0'
+inhibit_all_warnings!
 
-target 'TSMessages', :exclusive => true do
-  pod "TSMessages", :path => "../"
-end
-
-target 'Tests', :exclusive => true do
-  pod "TSMessages", :path => "../"
-
-  pod 'Specta', '~> 0.2.1'
-  pod 'Expecta'
-  pod 'FBSnapshotTestCase'
-  pod 'Expecta+Snapshots'
+target 'TSMessages' do
+    pod "TSMessages", :path => "../"
+    
+    target 'Tests' do
+        inherit! :search_paths
+        
+        pod 'Specta', '~> 0.2.1'
+        pod 'Expecta'
+        pod 'FBSnapshotTestCase'
+        pod 'Expecta+Snapshots'
+    end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,31 +1,37 @@
 PODS:
   - Expecta (0.3.1)
-  - Expecta+Snapshots (1.3.1):
+  - "Expecta+Snapshots (1.3.1)":
     - Expecta
     - FBSnapshotTestCase
   - FBSnapshotTestCase (1.4)
-  - HexColors (2.2.1)
   - Specta (0.2.1)
-  - TSMessages (0.9.12):
-    - HexColors
+  - TSMessages (0.9.13)
 
 DEPENDENCIES:
   - Expecta
-  - Expecta+Snapshots
+  - "Expecta+Snapshots"
   - FBSnapshotTestCase
   - Specta (~> 0.2.1)
   - TSMessages (from `../`)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Expecta
+    - "Expecta+Snapshots"
+    - FBSnapshotTestCase
+    - Specta
+
 EXTERNAL SOURCES:
   TSMessages:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Expecta: 03aabd0a89d8dea843baecb19a7fd7466a69a31d
-  Expecta+Snapshots: 4a56b9411c6ed156987072e52c39de67d864015a
-  FBSnapshotTestCase: f9f225b5ba11c8d8c09075590490df16314e4d62
-  HexColors: 01384d2bbe8dc4ffa43c3b4135db6e976952d153
-  Specta: 9141310f46b1f68b676650ff2854e1ed0b74163a
-  TSMessages: 3e67c231abe604e5ab732050ba6dc99df4650765
+  Expecta: a354d4633409dd9fe8c4f5ff5130426adbe31628
+  "Expecta+Snapshots": 4a0b46d3ba755bd43dffa7d53e4585fc6cbfe8cd
+  FBSnapshotTestCase: 892508495a69e8703bab36c9da7674ff740d41db
+  Specta: 15a276a6343867b426d5ed135d5aa4d04123a573
+  TSMessages: 188dfc1c43a67ebe6411690e077ec7dc32bbb0b8
 
-COCOAPODS: 0.36.0.beta.1
+PODFILE CHECKSUM: 8f9d05a07d8fc49030bcddac0ec35b1e7ece24d0
+
+COCOAPODS: 1.5.3

--- a/Example/TSMessages.xcodeproj/project.pbxproj
+++ b/Example/TSMessages.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1687DD9DDD3F49028DE52098 /* libPods-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D24C674F90784EC4AFFD8541 /* libPods-Tests.a */; };
-		2673C7B7BE2142E78B40DEE7 /* libPods-TSMessages.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DA65AE9564E43409150BC5E /* libPods-TSMessages.a */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -23,6 +21,8 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		6003F5BC195388D20070C39A /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5BB195388D20070C39A /* Tests.m */; };
+		85EEAA0F13B03CBC9E0B0E98 /* libPods-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D1CFC39587BCEB7E98D8EA5 /* libPods-Tests.a */; };
+		C23B0203819B41C16B0ED1A4 /* libPods-TSMessages.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3566CA1F459C38A4B87D9370 /* libPods-TSMessages.a */; };
 		CACA6CED19AB263400824626 /* TSDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CACA6CEC19AB263400824626 /* TSDemoViewController.m */; };
 		CAFB4A5D19ADC8CA004B4A82 /* AlternativeDesign.json in Resources */ = {isa = PBXBuildFile; fileRef = CAFB4A5C19ADC8CA004B4A82 /* AlternativeDesign.json */; };
 /* End PBXBuildFile section */
@@ -38,11 +38,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		06A5FE5AC1E4219F023CBC21 /* Pods-TSMessages.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSMessages.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TSMessages/Pods-TSMessages.debug.xcconfig"; sourceTree = "<group>"; };
-		26865537F27698DE43A2B821 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		3DA65AE9564E43409150BC5E /* libPods-TSMessages.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TSMessages.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3566CA1F459C38A4B87D9370 /* libPods-TSMessages.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TSMessages.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C10E90825C54E85A5FD6274 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		4DFA0B2B12013C4CF24E26C1 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		5FC9AAA9F7E58FECAA696F26 /* Pods-TSMessages.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSMessages.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TSMessages/Pods-TSMessages.debug.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* TSMessages.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TSMessages.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -64,11 +62,13 @@
 		6003F5BB195388D20070C39A /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		60FDB524217248DC8C80BCC7 /* TSMessages.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = TSMessages.podspec; path = ../TSMessages.podspec; sourceTree = "<group>"; };
+		621A040DC1C0080AF78A49AD /* Pods-TSMessages.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSMessages.release.xcconfig"; path = "Pods/Target Support Files/Pods-TSMessages/Pods-TSMessages.release.xcconfig"; sourceTree = "<group>"; };
+		64FAD25F5286A2741DC58EF1 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		6D1CFC39587BCEB7E98D8EA5 /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9BA86B6003D866EAEDB08FE5 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		CACA6CEB19AB263400824626 /* TSDemoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSDemoViewController.h; sourceTree = "<group>"; };
 		CACA6CEC19AB263400824626 /* TSDemoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSDemoViewController.m; sourceTree = "<group>"; };
 		CAFB4A5C19ADC8CA004B4A82 /* AlternativeDesign.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = AlternativeDesign.json; sourceTree = "<group>"; };
-		D24C674F90784EC4AFFD8541 /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F5AA9EEE57F49558023BAB5E /* Pods-TSMessages.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TSMessages.release.xcconfig"; path = "Pods/Target Support Files/Pods-TSMessages/Pods-TSMessages.release.xcconfig"; sourceTree = "<group>"; };
 		FECCD72F1B4F493A82447BE0 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -80,7 +80,7 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				2673C7B7BE2142E78B40DEE7 /* libPods-TSMessages.a in Frameworks */,
+				C23B0203819B41C16B0ED1A4 /* libPods-TSMessages.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,20 +91,20 @@
 				6003F5B0195388D20070C39A /* XCTest.framework in Frameworks */,
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
-				1687DD9DDD3F49028DE52098 /* libPods-Tests.a in Frameworks */,
+				85EEAA0F13B03CBC9E0B0E98 /* libPods-Tests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		5EE795FD5FA60C5F6C45E97E /* Pods */ = {
+		47D8D936ABFDC0562CEF31B5 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				06A5FE5AC1E4219F023CBC21 /* Pods-TSMessages.debug.xcconfig */,
-				F5AA9EEE57F49558023BAB5E /* Pods-TSMessages.release.xcconfig */,
-				26865537F27698DE43A2B821 /* Pods-Tests.debug.xcconfig */,
-				4DFA0B2B12013C4CF24E26C1 /* Pods-Tests.release.xcconfig */,
+				5FC9AAA9F7E58FECAA696F26 /* Pods-TSMessages.debug.xcconfig */,
+				621A040DC1C0080AF78A49AD /* Pods-TSMessages.release.xcconfig */,
+				64FAD25F5286A2741DC58EF1 /* Pods-Tests.debug.xcconfig */,
+				9BA86B6003D866EAEDB08FE5 /* Pods-Tests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -117,7 +117,7 @@
 				6003F5B5195388D20070C39A /* Tests */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
-				5EE795FD5FA60C5F6C45E97E /* Pods */,
+				47D8D936ABFDC0562CEF31B5 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -137,8 +137,8 @@
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
-				3DA65AE9564E43409150BC5E /* libPods-TSMessages.a */,
-				D24C674F90784EC4AFFD8541 /* libPods-Tests.a */,
+				3566CA1F459C38A4B87D9370 /* libPods-TSMessages.a */,
+				6D1CFC39587BCEB7E98D8EA5 /* libPods-Tests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -207,11 +207,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "TSMessages" */;
 			buildPhases = (
-				573E6F60FE3A47EF8559C1CC /* Check Pods Manifest.lock */,
+				0F15430F09B623BF25F2470C /* [CP] Check Pods Manifest.lock */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				98597394645B47438D90BF4D /* Copy Pods Resources */,
+				4ADA5E42746F0EDF93963CAE /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -226,11 +226,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "Tests" */;
 			buildPhases = (
-				F2B8A9A88DC94069A87B0DD6 /* Check Pods Manifest.lock */,
+				F12932FE2F1E2C90DD0B0D74 /* [CP] Check Pods Manifest.lock */,
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
-				051FD73A49EB413390345334 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -299,64 +298,90 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		051FD73A49EB413390345334 /* Copy Pods Resources */ = {
+		0F15430F09B623BF25F2470C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TSMessages-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		573E6F60FE3A47EF8559C1CC /* Check Pods Manifest.lock */ = {
+		4ADA5E42746F0EDF93963CAE /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TSMessages/Pods-TSMessages-resources.sh",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundError.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundError@2x.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundErrorIcon.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundErrorIcon@2x.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundMessage.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundMessage@2x.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundSuccess.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundSuccess@2x.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundSuccessIcon.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundSuccessIcon@2x.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundWarning.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundWarning@2x.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundWarningIcon.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationBackgroundWarningIcon@2x.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationButtonBackground.png",
+				"${PODS_ROOT}/../../Pod/Assets/NotificationButtonBackground@2x.png",
+				"${PODS_ROOT}/../../Pod/Assets/TSMessagesDefaultDesign.json",
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		98597394645B47438D90BF4D /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundError.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundError@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundErrorIcon.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundErrorIcon@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundMessage.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundMessage@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundSuccess.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundSuccess@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundSuccessIcon.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundSuccessIcon@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundWarning.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundWarning@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundWarningIcon.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationBackgroundWarningIcon@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationButtonBackground.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NotificationButtonBackground@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TSMessagesDefaultDesign.json",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TSMessages/Pods-TSMessages-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F2B8A9A88DC94069A87B0DD6 /* Check Pods Manifest.lock */ = {
+		F12932FE2F1E2C90DD0B0D74 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Tests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -516,7 +541,7 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 06A5FE5AC1E4219F023CBC21 /* Pods-TSMessages.debug.xcconfig */;
+			baseConfigurationReference = 5FC9AAA9F7E58FECAA696F26 /* Pods-TSMessages.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -531,7 +556,7 @@
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F5AA9EEE57F49558023BAB5E /* Pods-TSMessages.release.xcconfig */;
+			baseConfigurationReference = 621A040DC1C0080AF78A49AD /* Pods-TSMessages.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -546,7 +571,7 @@
 		};
 		6003F5C3195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 26865537F27698DE43A2B821 /* Pods-Tests.debug.xcconfig */;
+			baseConfigurationReference = 64FAD25F5286A2741DC58EF1 /* Pods-Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/TSMessages.app/TSMessages";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -570,7 +595,7 @@
 		};
 		6003F5C4195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4DFA0B2B12013C4CF24E26C1 /* Pods-Tests.release.xcconfig */;
+			baseConfigurationReference = 9BA86B6003D866EAEDB08FE5 /* Pods-Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/TSMessages.app/TSMessages";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Example/TSMessages.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/TSMessages.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Pod/Classes/HexColors.h
+++ b/Pod/Classes/HexColors.h
@@ -1,0 +1,31 @@
+//
+//  HexColor.h
+//
+//  Created by Marius Landwehr on 02.12.12.
+//  The MIT License (MIT)
+//  Copyright (c) 2013 Marius Landwehr marius.landwehr@gmail.com
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if (TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE)
+    #import <UIKit/UIKit.h>
+    #define HXColor UIColor
+#else
+    #import <Foundation/Foundation.h>
+    #define HXColor NSColor
+#endif
+
+@interface HXColor (HexColorAddition)
+
++ (HXColor *)colorWithHexString:(NSString *)hexString;
++ (HXColor *)colorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha;
+
++ (HXColor *)colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue;
++ (HXColor *)colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue alpha:(CGFloat)alpha;
+
+@end

--- a/Pod/Classes/HexColors.m
+++ b/Pod/Classes/HexColors.m
@@ -1,0 +1,93 @@
+//
+//  HexColor.m
+//
+//  Created by Marius Landwehr on 02.12.12.
+//  The MIT License (MIT)
+//  Copyright (c) 2013 Marius Landwehr marius.landwehr@gmail.com
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import "HexColors.h"
+
+@implementation HXColor (HexColorAddition)
+
++ (HXColor *)colorWithHexString:(NSString *)hexString
+{
+    return [[self class] colorWithHexString:hexString alpha:1.0];
+}
+
++ (HXColor *)colorWithHexString:(NSString *)hexString alpha:(CGFloat)alpha
+{
+    // Check for hash and add the missing hash
+    if('#' != [hexString characterAtIndex:0])
+    {
+        hexString = [NSString stringWithFormat:@"#%@", hexString];
+    }
+    
+    // check for string length
+    assert(7 == hexString.length || 4 == hexString.length);
+    
+    // check for 3 character HexStrings
+    hexString = [[self class] hexStringTransformFromThreeCharacters:hexString];
+    
+    NSString *redHex    = [NSString stringWithFormat:@"0x%@", [hexString substringWithRange:NSMakeRange(1, 2)]];
+    unsigned redInt = [[self class] hexValueToUnsigned:redHex];
+    
+    NSString *greenHex  = [NSString stringWithFormat:@"0x%@", [hexString substringWithRange:NSMakeRange(3, 2)]];
+    unsigned greenInt = [[self class] hexValueToUnsigned:greenHex];
+    
+    NSString *blueHex   = [NSString stringWithFormat:@"0x%@", [hexString substringWithRange:NSMakeRange(5, 2)]];
+    unsigned blueInt = [[self class] hexValueToUnsigned:blueHex];
+    
+    HXColor *color = [HXColor colorWith8BitRed:redInt green:greenInt blue:blueInt alpha:alpha];
+    
+    return color;
+}
+
++ (HXColor *)colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue
+{
+    return [[self class] colorWith8BitRed:red green:green blue:blue alpha:1.0];
+}
+
++ (HXColor *)colorWith8BitRed:(NSInteger)red green:(NSInteger)green blue:(NSInteger)blue alpha:(CGFloat)alpha
+{
+    HXColor *color = [[HXColor alloc] init];
+#if (TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE)
+    color = [HXColor colorWithRed:(float)red/255 green:(float)green/255 blue:(float)blue/255 alpha:alpha];
+#else
+    color = [HXColor colorWithCalibratedRed:(float)red/255 green:(float)green/255 blue:(float)blue/255 alpha:alpha];
+#endif
+    
+    return color;
+}
+
++ (NSString *)hexStringTransformFromThreeCharacters:(NSString *)hexString
+{
+    if(hexString.length == 4)
+    {
+        hexString = [NSString stringWithFormat:@"#%@%@%@%@%@%@",
+                     [hexString substringWithRange:NSMakeRange(1, 1)],[hexString substringWithRange:NSMakeRange(1, 1)],
+                     [hexString substringWithRange:NSMakeRange(2, 1)],[hexString substringWithRange:NSMakeRange(2, 1)],
+                     [hexString substringWithRange:NSMakeRange(3, 1)],[hexString substringWithRange:NSMakeRange(3, 1)]];
+    }
+    
+    return hexString;
+}
+
++ (unsigned)hexValueToUnsigned:(NSString *)hexValue
+{
+    unsigned value = 0;
+    
+    NSScanner *hexValueScanner = [NSScanner scannerWithString:hexValue];
+    [hexValueScanner scanHexInt:&value];
+    
+    return value;
+}
+
+
+@end

--- a/TSMessages.podspec
+++ b/TSMessages.podspec
@@ -30,5 +30,4 @@ There are 4 different types already set up for you: Success, Error, Warning, Mes
   s.resources = ['Pod/Assets/*.png', 'Pod/Assets/*.json']
 
   s.public_header_files = 'Pod/Classes/**/*.h'
-  s.dependency 'HexColors', '~> 2.3.0'
 end


### PR DESCRIPTION
I removed the submodules for HexColor and added it as a source file so that we don't need to also fork the dependency, which isn't maintained anymore. This is part of the Carthage conversion for this repo.